### PR TITLE
LandertronBox module

### DIFF
--- a/Landertron/Landertron.csproj
+++ b/Landertron/Landertron.csproj
@@ -52,6 +52,7 @@
     <Compile Include="source\ModeHandlers\ShortLandingHandler.cs" />
     <Compile Include="source\ModeHandlers\SoftLandingHandler.cs" />
     <Compile Include="source\ModeHandlers\StayPutHandler.cs" />
+    <Compile Include="source\LandertronBox.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="dependencies\Assembly-CSharp.dll" />

--- a/Landertron/source/Landertron.cs
+++ b/Landertron/source/Landertron.cs
@@ -68,14 +68,16 @@ namespace Landertron
         }
 
         // KSPField doesn't like enums or properties so this will be persisted in OnLoad/OnSave.
-        Status _status = Status.Idle;
-        public Status status
+        //Status _status = Status.Idle;
+        public Status _status = Status.Idle;
+        virtual public Status status
         {
             get
             {
                 return _status;
             }
-            private set
+            //private set
+            set
             {
                 if (_status != value)
                     setStatus(value);
@@ -98,7 +100,7 @@ namespace Landertron
             }
         }
 
-        public Vector3d engineThrust
+        virtual public Vector3d engineThrust
         {
             get
             {
@@ -113,7 +115,7 @@ namespace Landertron
             }
         }
 
-        public double engineBurnTime
+        virtual public double engineBurnTime
         {
             get
             {
@@ -260,19 +262,19 @@ namespace Landertron
                 if (part.RequestResource("ElectricCharge", electricReq) < electricReq)
                 {
                     disarm();
-                    ScreenMessages.PostScreenMessage("Landertron ouf of electric charge, disarming!", 5, ScreenMessageStyle.UPPER_CENTER);
+                    ScreenMessages.PostScreenMessage("Landertron out of electric charge, disarming!", 5, ScreenMessageStyle.UPPER_CENTER);
                 }
             }
         }
 
-        internal void fire()
+        virtual internal void fire()
         {
             log.debug("Firing engine");
             engine.Activate();
             status = Status.Firing;
         }
 
-        internal void shutdown()
+        virtual internal void shutdown()
         {
             if (engine.allowShutdown)
             {

--- a/Landertron/source/Landertron.cs
+++ b/Landertron/source/Landertron.cs
@@ -60,7 +60,7 @@ namespace Landertron
             {
                 return _mode;
             }
-            private set
+            protected set
             {
                 if (_mode != value)
                     setMode(value);
@@ -76,8 +76,7 @@ namespace Landertron
             {
                 return _status;
             }
-            //private set
-            set
+            protected set
             {
                 if (_status != value)
                     setStatus(value);
@@ -124,6 +123,14 @@ namespace Landertron
                 return fuelMass / fuelFlow;
             }
         }
+
+        //virtual public double engineFuelFlow
+        //{
+        //    get
+        //    {
+        //        return Mathf.Lerp(engine.minFuelFlow, engine.maxFuelFlow, engine.thrustPercentage / 100);
+        //    }
+        //}
 
         ModuleEngines engine;
         PartResource propellantResource;
@@ -289,20 +296,20 @@ namespace Landertron
             }
         }
 
-        private void ventFuel()
+        protected void ventFuel()
         {
             log.debug("Venting fuel: " + propellantResource.amount);
             propellantResource.amount = 0;
             status = Status.Empty;
         }
 
-        private void setMode(Mode value)
+        protected void setMode(Mode value)
         {
             _mode = value;
             Events["nextMode"].guiName = "Mode: " + mode.ToString();
         }
 
-        private void setStatus(Status value)
+        protected void setStatus(Status value)
         {
             _status = value;
             log.info("Status set to " + _status.ToString());
@@ -347,7 +354,7 @@ namespace Landertron
             }
         }
 
-        private void refuel()
+        protected void refuel()
         {
             bool justrefueled = false;
             for (int i = 0; i < part.children.Count; )
@@ -373,7 +380,7 @@ namespace Landertron
             }
         }
 
-        private void forAllSym()
+        protected void forAllSym()
         {
             foreach (Part p in part.symmetryCounterparts)
             {
@@ -382,7 +389,7 @@ namespace Landertron
             }
         }
 
-        private static AnimationState[] setUpAnimation(string animationName, Part part)  //Thanks Majiir!
+        protected static AnimationState[] setUpAnimation(string animationName, Part part)  //Thanks Majiir!
         {
             var states = new List<AnimationState>();
             foreach (var animation in part.FindModelAnimators(animationName))
@@ -397,7 +404,7 @@ namespace Landertron
             return states.ToArray();
         }
 
-        private void updateAnimation()
+        protected void updateAnimation()
         {
             foreach (AnimationState anim in animStates)
             {

--- a/Landertron/source/LandertronBox.cs
+++ b/Landertron/source/LandertronBox.cs
@@ -1,0 +1,171 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Landertron
+{
+    public class LandertronBox : Landertron
+    {
+        [KSPField]
+        new public bool refuelable = false;
+
+        override public Vector3d engineThrust
+        {
+            get
+            {
+                Vector3d sumVector = Vector3d.zero;
+                foreach (var engine in engines) {
+                    Vector3d vector = Vector3d.zero;
+                    foreach (var transform in engine.thrustTransforms)
+                        vector -= transform.forward;
+                    vector.Normalize ();
+                    double isp = engine.atmosphereCurve.Evaluate ((float)engine.part.staticPressureAtm);
+                    double fuelFlow = Mathf.Lerp (engine.minFuelFlow, engine.maxFuelFlow, engine.thrustPercentage / 100);
+                    double thrust = fuelFlow * isp * engine.g;
+                    sumVector += vector * thrust;
+                }
+                // In case there is more than one box on the vessel, return a fraction of the total
+                // since they're being summed elsewhere and this is the easiest method of returning
+                // the total overall.
+                int boxes = 0;
+                foreach (var p in vessel.FindPartModulesImplementing<LandertronBox>()) {
+                    if (p.isArmed|p.isFiring)
+                        boxes += 1;
+                }
+                sumVector = sumVector / boxes;
+                log.debug ("LandertronBox: "+sumVector.magnitude.ToString()+":"+boxes.ToString());
+                return sumVector;
+            }
+        }
+
+        override public double engineBurnTime
+        {
+            get
+            {
+                double result = 0;
+                //foreach (var engine in engines) {
+                //    double fuelFlow = Mathf.Lerp (engine.minFuelFlow, engine.maxFuelFlow, engine.thrustPercentage / 100);
+                //    double fuelMass = propellantResource.amount * propellantResource.info.density;
+                //    result += fuelMass / fuelFlow;
+                //}
+                result = double.PositiveInfinity;
+                return result;
+            }
+        }
+
+        List<ModuleEngines> engines = new List<ModuleEngines>();
+        //List<List<ModuleResource>> propellantResource = new List<List<ModuleResource>>();
+        Logger log = new Logger("[Landertron] ");
+
+        public override void OnStart(PartModule.StartState state)
+        {
+            if(!(status == Status.Idle))
+                checkEngines ();
+        }
+
+        public override void OnUpdate()
+        {
+        }
+
+        private void checkEngines ()
+        {
+            log.prefix = "[Landertron:" + part.flightID + "] ";
+            //log.debug("Checking for engines.");
+            engines.Clear ();
+            foreach (var p in vessel.parts) {
+            //foreach (var p in vessel.FindPartModulesImplementing<ModuleEngines>()){
+                ModuleEngines engine = new ModuleEngines();
+                if (!p.Modules.Contains ("Landertron")) {
+                    if (p.Modules.Contains ("ModuleEngines")) {
+                        engine = p.Modules ["ModuleEngines"] as ModuleEngines;
+                    } else if (p.Modules.Contains ("ModuleEnginesFX")) {
+                        engine = p.Modules ["ModuleEnginesFX"] as ModuleEngines;
+                    } else if (p.Modules.Contains ("ModuleEnginesRF")) {
+                        engine = p.Modules ["ModuleEnginesRF"] as ModuleEngines;
+                    } else {
+                        continue;
+                    }
+                }
+                if (engine.EngineIgnited) {
+                    //log.debug ("Added engine." + engine.maxThrust.ToString());
+                    if (!engine.flameout) {
+                        engines.Add (engine);
+                    }
+                }
+            }
+
+            //if (engines.Count == 0)
+            //    log.error("No engine found! Will crash!");
+            
+            //propellantResource = part.Resources.Get(engine.propellants[0].id);
+        }
+
+        public override void OnFixedUpdate()
+        {
+            if (!(status == Status.Idle)) {
+                checkEngines ();
+                if (engines.Count <= 0) {
+                    status = Status.Empty;
+                } else if (status == Status.Empty) {
+                    status = Status.Idle;
+                }
+            }
+
+            if (status == Status.Armed)
+            {
+                float electricReq = electricRate * TimeWarp.fixedDeltaTime;
+                if (part.RequestResource("ElectricCharge", electricReq) < electricReq)
+                {
+                    disarm();
+                    ScreenMessages.PostScreenMessage("Landertron out of electric charge, disarming!", 5, ScreenMessageStyle.UPPER_CENTER);
+                }
+            }
+            if (status == Status.Firing) {
+                throttle = 1.0f;
+                vessel.OnFlyByWire += setThrottle;
+            }
+        }
+
+        float throttle = 0.0f;
+
+        override internal void fire()
+        {
+            log.prefix = "[Landertron:" + part.flightID + "] ";
+            log.debug("Firing engines");
+            status = Status.Firing;
+            throttle = 1.0f;
+            vessel.OnFlyByWire += setThrottle;
+            //foreach (var engine in engines) {
+                //engine.requestedThrottle = 100;
+            //}
+        }
+
+        void setThrottle(FlightCtrlState s){
+            if(status == Status.Firing)
+                s.mainThrottle = throttle;
+        }
+
+        override internal void shutdown()
+        {
+            log.prefix = "[Landertron:" + part.flightID + "] ";
+            log.debug("Shutting down engines");
+            throttle = 0.0f;
+            vessel.OnFlyByWire += setThrottle;
+            foreach (var engine in engines) {
+                if (engine.throttleLocked) {
+                    engine.Shutdown ();
+                }
+            }
+            if (!vessel.LandedOrSplashed) {
+                if (Math.Min (vessel.terrainAltitude, vessel.altitude) * vessel.mainBody.GeeASL * 9.81 * 2 > 2.64) {
+                    status = Status.Armed;
+                } else {
+                    status = Status.Idle;
+                }
+            } else {
+                status = Status.Idle;
+            }
+        }
+    }
+}
+

--- a/Landertron/source/ModeHandlers/SoftLandingHandler.cs
+++ b/Landertron/source/ModeHandlers/SoftLandingHandler.cs
@@ -50,7 +50,7 @@ namespace Landertron
             log.debug("Distance to ground: " + distanceToGround + ", next frame: " + nextFrameDistanceToGround);
             if (distanceToGround <= 0) // already on the ground
                 return false;
-
+            
             double finalAcc = Vector3d.Dot(vessel.acceleration, thrustDirection) + combinedThrust.magnitude / vessel.GetTotalMass();
             double timeToStop = -projectedSpeed / finalAcc;
             double burnTime = getMinBurnTime(armedLandertrons);
@@ -87,29 +87,29 @@ namespace Landertron
             return minBurnTime;
         }
 
-        private double calculateDistanceToGround(Vessel vessel, Vector3d direction)
+        public double calculateDistanceToGround(Vessel vessel, Vector3d direction)
         {
             Vector3d position = vessel.findWorldCenterOfMass();
             RaycastHit hit;
             if (!Physics.Raycast(position, direction, out hit, float.PositiveInfinity, 1 << 15))
                 return double.PositiveInfinity;
 
-			double distanceToTerrain = hit.distance;
+            double distanceToTerrain = hit.distance;
 
-			double distanceToWater = double.PositiveInfinity;
+            double distanceToWater = double.PositiveInfinity;
 
-			if (vessel.mainBody.ocean) {  // Do a little trig to see if/where our current trajectory will intersect the sea-level sphere (which the raycast doesn't detect).
-				Vector3d down = (vessel.mainBody.position - vessel.CoM).normalized;
-				double cosTheta = Vector3d.Dot (down, direction);
-				double r = vessel.mainBody.Radius;
-				double a = r + vessel.altitude;
-				double discriminant = Math.Pow (a, 2) * Math.Pow (cosTheta, 2) - (Math.Pow (a, 2) - Math.Pow (r, 2)); //It's divided by a factor of four from the usual discriminant, because the discriminant will just get sqrted and divided by 2 anyway.
-				if (discriminant >= 0) {
-					distanceToWater = a * cosTheta - Math.Sqrt (discriminant);
-				}
-			}
+            if (vessel.mainBody.ocean) {  // Do a little trig to see if/where our current trajectory will intersect the sea-level sphere (which the raycast doesn't detect).
+                Vector3d down = (vessel.mainBody.position - vessel.CoM).normalized;
+                double cosTheta = Vector3d.Dot (down, direction);
+                double r = vessel.mainBody.Radius;
+                double a = r + vessel.altitude;
+                double discriminant = Math.Pow (a, 2) * Math.Pow (cosTheta, 2) - (Math.Pow (a, 2) - Math.Pow (r, 2)); //It's divided by a factor of four from the usual discriminant, because the discriminant will just get sqrted and divided by 2 anyway.
+                if (discriminant >= 0) {
+                    distanceToWater = a * cosTheta - Math.Sqrt (discriminant);
+                }
+            }
 
-			double distanceToImpact = Math.Min (distanceToTerrain, distanceToWater);
+            double distanceToImpact = Math.Min (distanceToTerrain, distanceToWater);
 
             Vector3d fakeInfinity = position + 1000 * direction;
             double maxExtent = 0;
@@ -122,7 +122,7 @@ namespace Landertron
                 }
             }
 
-			return distanceToImpact - maxExtent;
+            return distanceToImpact - maxExtent;
         }
     }
 }


### PR DESCRIPTION
This includes all of the changes required to implement a PartModule where the Landertron logic is carried out by a single part and then fires with all activated engines at the appropriate time.

LandertronBox (as I've called it, feel free to rename) is a child class of the base Landertron class. This means that it can be treated by the mode handlers and controller as any other landertron. By marking the methods used in the base class as 'virtual', it is able to override them with its own methods. Similarly, by making the previously private properties and methods 'protected' it is also able to carry out anything that the base class can.

The only change aside from making the base Landertron class accessible to child classes and the implementation of the child LandertronBox class is a minor change to the SoftLandingHandler class to allow the LandertronBox class to access its method for calculating height above ground. This is used to determine whether or not it is desirable to re-arm the engines on shutdown (ie. if the vessel is still significantly above the surface). Note that this behaviour is still somewhat buggy in that it can result in bouncing a few meters above the surface in some conditions.

Note also that the engineBurnTime calculation for the LandertronBox always returns positive infinity at this point because the algorithm I've used always seems to give too-small numbers. Maybe you can take a look at it. Or we can assume the user has sufficient fuel. :p
