### PR TITLE
Size adjustments for better fit to small probes

### DIFF
--- a/GameData/Landertron/Parts/XT-LB/lkrab.cfg
+++ b/GameData/Landertron/Parts/XT-LB/lkrab.cfg
@@ -4,20 +4,20 @@ PART
 	module = Part
 	author = Kerbas_ad_astra, steedcrugeon
 	model = lkrab.mu
-	rescaleFactor = 1
+	rescaleFactor = 0.71
 	PhysicsSignificance = 1
 	node_attach = 0, 0.015, 0, 0, -1, 0, 0
 	CrewCapacity = 0
 	TechRequired = advLanding
 	entryCost = 7500
-	cost = 1500
+	cost = 500
 	category = Control
 	subcategory = 0
 	title = #autoLOC_XTL_XTLB_title
 	manufacturer = #autoLOC_XTL_XT_mfg
 	description = #autoLOC_XTL_XTLB_desc
 	attachRules = 0,1,0,0,0
-	mass = 0.05
+	mass = 0.01
 	dragModelType = default
 	maximum_drag = 0.15
 	minimum_drag = 0.15
@@ -38,7 +38,7 @@ PART
 	MODULE
 	{
 		name = LandertronBox
-		electricRate = 0.05
+		electricRate = 0.02
 		stagingEnabled = true
 	}
 }


### PR DESCRIPTION
Hello and thank you for bringing landertrons back, they have been missed!

I propose those changes to the box, so that it becomes more useful for tiny probes. At the moment the box has the size of a probe core with reaction wheel and is quite heavy, EC hungry and pricy in comparison as well. So when building a small probe lander, it seems a bit off at the moment. With the new size it fits nicely on the side of a standard probe core, like the HEX.